### PR TITLE
link should be done with SFITSIO and SLLIB in order.

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -96,7 +96,7 @@ set_source_files_properties(${SWIG_IF_FILE} PROPERTIES CPLUSPLUS ON)
 set_source_files_properties(${SWIG_IF_FILE} PROPERTIES SWIG_FLAGS "-autorename")
 add_definitions(-DHAVE_STRUCT_TIMESPEC -DHAVE_STRUCT_TIMEVAL -DHAVE_SIGNBIT)
 swig_add_module(${TARGET_EXT_LIBRARY} ruby ${SWIG_IF_FILE})
-swig_link_libraries(${TARGET_EXT_LIBRARY} ${RUBY_LIBRARY} ${LIBSLLIB} ${LIBSFITSIO} )
+swig_link_libraries(${TARGET_EXT_LIBRARY} ${RUBY_LIBRARY} ${LIBSFITSIO} ${LIBSLLIB})
 
 if(APPLE)
   set(RUBY_BINDING_SUFFIX ".bundle")


### PR DESCRIPTION
if the order is SLLIB at first, then SFITSIO,
it causes symbol not found error.

environment: FreeBSD/amd64 11.0-CURRENT
